### PR TITLE
Add bower configuration file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "escope",
+  "version": "0.0.14-dev",
+  "main": "escope.js",
+  "dependencies": {
+        "estraverse": ">= 0.0.2"
+  },  
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components"
+  ]
+}


### PR DESCRIPTION
[Bower](http://bower.io/) is a package manager for the web. Estraverse is already [registered](http://sindresorhus.com/bower-components/). So it will be good to have escope registred too. For that we need:
- to have `bower.json` configuration file in the github repository (with estraverse dependency record) 
- install bower `sudo npm -g bower`
- And register package `bower register git@github.com:Constellation/escope.git` 

It's possible to register package without `bower.json` file (like it was done for estraverse), but in this case we will lose dependency information.

[![Bower](https://si0.twimg.com/profile_images/3536632979/66db62603f426a8fc6664081811be6d4_normal.png)](http://bower.io/)
