### PR TITLE
Implement ignoreEval option to analyze. Fixes #2.

### DIFF
--- a/escope.js
+++ b/escope.js
@@ -523,10 +523,11 @@
     function analyze(tree, options) {
         var resultScopes;
 
+        options = options || {};
         resultScopes = scopes = [];
         currentScope = null,
         globalScope = null;
-        directive = options && options.directive;
+        directive = options.directive;
 
         // attach scope and collect / resolve names
         estraverse.traverse(tree, {
@@ -579,7 +580,7 @@
                     }
 
                     // check this is direct call to eval
-                    if (node.callee.type === Syntax.Identifier && node.callee.name === 'eval') {
+                    if (!options.ignoreEval && node.callee.type === Syntax.Identifier && node.callee.name === 'eval') {
                         currentScope.variableScope.__detectEval();
                     }
                     break;


### PR DESCRIPTION
We want this because we want `J` in

```
function () {
  var J;
  J = 3;
  eval("foo");
}
```

to count as resolved! I'm really not sure why it isn't just because there's an eval there...
