### PR TITLE
Point links to estools org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ scope analyzer extracted from [esmangle project](http://github.com/estools/esman
 
 ### Document
 
-Generated JSDoc is [here](http://constellation.github.io/escope/).
+Generated JSDoc is [here](http://estools.github.io/escope/).
 
 ### Demos and Tools
 

--- a/escope.js
+++ b/escope.js
@@ -25,10 +25,10 @@
 */
 
 /**
- * Escope (<a href="http://github.com/Constellation/escope">escope</a>) is an <a
+ * Escope (<a href="http://github.com/estools/escope">escope</a>) is an <a
  * href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript</a>
  * scope analyzer extracted from the <a
- * href="http://github.com/Constellation/esmangle">esmangle project</a/>.
+ * href="http://github.com/estools/esmangle">esmangle project</a/>.
  * <p>
  * <em>escope</em> finds lexical scopes in a source program, i.e. areas of that
  * program where different occurrences of the same identifier refer to the same


### PR DESCRIPTION
The links to constellation/escope weren't updated when the project was moved under the estools org. So far I found and fixed three:
- Link to generated JSDoc in README
- Link to estools/escope in comment in `escope.js`
- Link to estools/esmangle in comment in `escope.js`

_Edit: I found more links, so I updated the PR to include them._
