### PR TITLE
Fix: Labeled statement ref counting (refs #33)

### DIFF
--- a/src/referencer.js
+++ b/src/referencer.js
@@ -420,7 +420,9 @@ export default class Referencer extends esrecurse.Visitor {
 
     ContinueStatement() {}
 
-    LabeledStatement() {}
+    LabeledStatement(node) {
+        this.visit(node.body);
+    }
 
     ForStatement(node) {
         // Create ForStatement declaration.

--- a/test/label.coffee
+++ b/test/label.coffee
@@ -47,4 +47,24 @@ describe 'label', ->
         expect(scope.isArgumentsMaterialized()).to.be.false
         expect(scope.references).to.have.length 0
 
+    it 'should count child node references', ->
+            ast = esprima.parse """
+            var foo = 5;
+
+            label: while (true) {
+              console.log(foo);
+              break;
+            }
+            """
+
+            scopeManager = escope.analyze ast
+            expect(scopeManager.scopes).to.have.length 1
+            globalScope = scopeManager.scopes[0]
+            expect(globalScope.type).to.be.equal 'global'
+            expect(globalScope.variables).to.have.length 1
+            expect(globalScope.variables[0].name).to.be.equal 'foo'
+            expect(globalScope.through.length).to.be.equal 3
+            expect(globalScope.through[2].identifier.name).to.be.equal 'foo'
+            expect(globalScope.through[2].isRead()).to.be.true
+
 # vim: set sw=4 ts=4 et tw=80 :


### PR DESCRIPTION
This fixes the issue with labeled statements that I mentioned in https://github.com/estools/escope/issues/33#issuecomment-72323191. Looks like escope just wasn't traversing into labeled statements.