### PR TITLE
v1.x.x

### DIFF
--- a/escope.js
+++ b/escope.js
@@ -1107,7 +1107,7 @@
     }
 
     /** @name module:escope.version */
-    exports.version = '1.0.2-dev';
+    exports.version = '1.0.3';
     /** @name module:escope.Reference */
     exports.Reference = Reference;
     /** @name module:escope.Variable */

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "ECMAScript scope analyzer",
   "homepage": "http://github.com/Constellation/escope.html",
   "main": "escope.js",
-  "version": "1.0.2-dev",
+  "version": "1.0.3",
   "engines": {
     "node": ">=0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "http://github.com/Constellation/escope.git"
   },
   "dependencies": {
-    "estraverse": ">=1.7.1"
+    "estraverse": "^2.0.0"
   },
   "devDependencies": {
     "jshint": "~2.5.10",

--- a/test/catch-scope.coffee
+++ b/test/catch-scope.coffee
@@ -1,0 +1,48 @@
+# Copyright (C) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'use strict'
+
+expect = require('chai').expect
+escope = require '..'
+esprima = require 'esprima'
+
+describe 'catch scope', ->
+    it 'isolates catch block scope', ->
+        ast = esprima.parse """
+        try {} catch (error) {}
+        """
+
+        scopes = escope.analyze(ast).scopes
+
+        expect(scopes.map((scope) ->
+            scope.variables.map((variable) -> variable.name))).to.be.eql(
+            [
+                [
+                ]
+                [
+                    'error'
+                ]
+            ]
+        )
+
+        expect(scopes[0].implicit.variables.map((variable) -> variable.name)).to.be.eql([])


### PR DESCRIPTION
A recent update to extraverse breaks an old version of this package. This patch restricts `extraverse` to the last version known to work with the v1.x.x lineage of this package.

I would like you to create a new branch starting at 74b2f47 (I recommend calling it "v1.x.x"), merge this commit into that branch, and release `1.0.3` on npm.

My package [scopifier](https://github.com/jacksonrayhamilton/scopifier) (a component of [context-coloring](https://github.com/jacksonrayhamilton/context-coloring)) uses version `^1.0.1` of this package. A few hours ago [one of my tests started failing](https://travis-ci.org/jacksonrayhamilton/context-coloring/builds/54384834), and I believe this is due to a backwards-incompatible change made to extraverse, which this package picked up thanks to the `>=` operator used in its comparator for that package dependency.

I believe the backwards-incompatible change broke catch block scopes, as the test was

```lisp
(defun context-coloring-test-js-catch ()
  "Test fixtures/js-catch.js."
  (context-coloring-test-assert-region-level 20 27 1)
  (context-coloring-test-assert-region-level 27 51 2)
  (context-coloring-test-assert-region-level 51 52 1)
  (context-coloring-test-assert-region-level 52 73 2)
  (context-coloring-test-assert-region-level 73 101 3)
  (context-coloring-test-assert-region-level 101 102 1)
  (context-coloring-test-assert-region-level 102 117 3)
  (context-coloring-test-assert-region-level 117 123 2))
```

and the fixture was

```js
(function () {
    try {} catch (e) {
        var a = e;
        try {} catch (e) {
            var a = e;
        }
    }
}());
```

the reason for my test's failure was

```
Test context-coloring-test-js-mode-catch condition:
    (ert-test-failed "Expected level in region [27, 51), which is \"catch (e) {\n        var \", to be 2; but at point 27, it was 1")
```

I made the changes that you see in this branch, ran `npm install` in this package's directory, ran `npm link ../escope` from my scopifier project directory, also ran `npm link` from my scopifier project directory, and now my test is passing again.

I do not wish to upgrade my version of this package at this time, primarily because I have noticed a degradation of performance in newer versions of this package, and also because ECMAScript 6 is not yet standardized and I am not interested in maintaining code for a language that doesn't exist yet.

Thanks for your help.