### PR TITLE
Fix the reference resolving logic for global.

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -115,6 +115,13 @@ function registerScope(scopeManager, scope) {
     }
 }
 
+function shouldBeStatically(def) {
+    return (
+        (def.type === Variable.ClassName) ||
+        (def.type === Variable.Variable && def.parent.kind !== "var")
+    );
+}
+
 /**
  * @class Scope
  */
@@ -235,12 +242,8 @@ export default class Scope {
         }
 
         var variable = this.set.get(name);
-        //TODO: Confirm the mean of array, and rewrite.
-        var def = variable.defs[0];
-        return def != null && (
-            (def.type === Variable.ClassName) ||
-            (def.type === Variable.Variable && def.parent.kind !== "var")
-        );
+        var defs = variable.defs;
+        return defs.length > 0 && defs.every(shouldBeStatically);
     }
 
     __staticCloseRef(ref) {
@@ -263,8 +266,7 @@ export default class Scope {
         // others should be resolved dynamically.
         if (this.__shouldStaticallyCloseForGlobal(ref)) {
             this.__staticCloseRef(ref);
-        }
-        else {
+        } else {
             this.__dynamicCloseRef(ref);
         }
     }

--- a/test/references.coffee
+++ b/test/references.coffee
@@ -70,53 +70,6 @@ describe 'References:', ->
             expect(reference.isWrite()).to.be.false
             expect(reference.isRead()).to.be.true
 
-        it 'the reference in default parameters should be resolved.', ->
-            ast = harmony.parse """
-            let a = 0;
-            function foo(b = a) {
-            }
-            """
-
-            console.log(JSON.stringify(ast, null, 2))
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
-
-            scope = scopeManager.scopes[1]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default values of destructuring should be resolved.', ->
-            ast = harmony.parse """
-            let a = 0;
-            function foo() {
-                let {b: a} = {};
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
-
-            scope = scopeManager.scopes[1]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
     describe 'When there is a `const` declaration on global,', ->
         it 'the reference on global should be resolved.', ->
             ast = harmony.parse """
@@ -161,51 +114,6 @@ describe 'References:', ->
             expect(reference.isWrite()).to.be.false
             expect(reference.isRead()).to.be.true
 
-        it 'the reference in default parameters should be resolved.', ->
-            ast = harmony.parse """
-            const a = 0;
-            function foo(b = a) {
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
-
-            scope = scopeManager.scopes[1]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default values of destructuring should be resolved.', ->
-            ast = harmony.parse """
-            const a = 0;
-            function foo() {
-                const {b: a} = {};
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
-
-            scope = scopeManager.scopes[1]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
     describe 'When there is a `var` declaration on global,', ->
         it 'the reference on global should NOT be resolved.', ->
             ast = harmony.parse """
@@ -232,51 +140,6 @@ describe 'References:', ->
             var a = 0;
             function foo() {
                 var b = a;
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
-
-            scope = scopeManager.scopes[1]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.be.null
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default parameters should NOT be resolved.', ->
-            ast = harmony.parse """
-            var a = 0;
-            function foo(b = a) {
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
-
-            scope = scopeManager.scopes[1]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.be.null
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default values of destructuring should NOT be resolved.', ->
-            ast = harmony.parse """
-            var a = 0;
-            function foo() {
-                var {b: a} = {};
             }
             """
 
@@ -340,51 +203,6 @@ describe 'References:', ->
             expect(reference.isWrite()).to.be.false
             expect(reference.isRead()).to.be.true
 
-        it 'the reference in default parameters should NOT be resolved.', ->
-            ast = harmony.parse """
-            function a() {}
-            function foo(b = a()) {
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 3  # [global, a, foo]
-
-            scope = scopeManager.scopes[2]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.be.null
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default values of destructuring should NOT be resolved.', ->
-            ast = harmony.parse """
-            function a() {}
-            function foo() {
-                let {b: a()} = {};
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 3  # [global, a, foo]
-
-            scope = scopeManager.scopes[2]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.be.null
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
     describe 'When there is a `class` declaration on global,', ->
         it 'the reference on global should be resolved.', ->
             ast = harmony.parse """
@@ -421,51 +239,6 @@ describe 'References:', ->
             scope = scopeManager.scopes[2]
             expect(scope.variables).to.have.length 2  # [arguments, b]
             expect(scope.references).to.have.length 2  # [b, A]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'A'
-            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default parameters should be resolved.', ->
-            ast = harmony.parse """
-            class A {}
-            function foo(b = new A()) {
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 3  # [global, A, foo]
-
-            scope = scopeManager.scopes[2]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, A]
-
-            reference = scope.references[1]
-            expect(reference.from).to.equal scope
-            expect(reference.identifier.name).to.equal 'A'
-            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
-
-        it 'the reference in default values of destructuring should be resolved.', ->
-            ast = harmony.parse """
-            class A {}
-            function foo() {
-                let {b: new A()} = {};
-            }
-            """
-
-            scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 3  # [global, A, foo]
-
-            scope = scopeManager.scopes[2]
-            expect(scope.variables).to.have.length 2  # [arguments, A]
-            expect(scope.references).to.have.length 2  # [b, a]
 
             reference = scope.references[1]
             expect(reference.from).to.equal scope
@@ -523,36 +296,35 @@ describe 'References:', ->
             expect(reference.isWrite()).to.be.false
             expect(reference.isRead()).to.be.true
 
-        it 'the reference in default parameters body should be resolved.', ->
+    describe 'When there is a `var` declaration in functions,', ->
+        it 'the reference on the function should be resolved.', ->
             ast = harmony.parse """
             function foo() {
-                let a = 0;
-                function bar(b = a) {
-                }
+                var a = 0;
             }
             """
 
             scopeManager = escope.analyze ast, ecmaVersion: 6
-            expect(scopeManager.scopes).to.have.length 3  # [global, foo, bar]
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
 
-            scope = scopeManager.scopes[2]
-            expect(scope.variables).to.have.length 2  # [arguments, b]
-            expect(scope.references).to.have.length 2  # [b, a]
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, a]
+            expect(scope.references).to.have.length 1
 
-            reference = scope.references[1]
+            reference = scope.references[0]
             expect(reference.from).to.equal scope
             expect(reference.identifier.name).to.equal 'a'
-            expect(reference.resolved).to.equal scopeManager.scopes[1].variables[1]
-            expect(reference.writeExpr).to.be.undefined
-            expect(reference.isWrite()).to.be.false
-            expect(reference.isRead()).to.be.true
+            expect(reference.resolved).to.equal scope.variables[1]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
 
-        it 'the reference in default values of destructuring should be resolved.', ->
+        it 'the reference in nested functions should be resolved.', ->
             ast = harmony.parse """
             function foo() {
-                let a = 0;
+                var a = 0;
                 function bar() {
-                    let {b: a} = {};
+                    var b = a;
                 }
             }
             """

--- a/test/references.coffee
+++ b/test/references.coffee
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+#  Copyright (C) 2015 Toru Nagashima
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+#  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+expect = require('chai').expect
+harmony = require '../third_party/esprima'
+escope = require '..'
+
+describe 'References:', ->
+    it '"let a = 0;" should have a writable reference on global.', ->
+        ast = harmony.parse """
+        let a = 0;
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 1
+
+        scope = scopeManager.scopes[0]
+        expect(scope.variables).to.have.length 1
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.equal scope.variables[0]
+        expect(reference.writeExpr).to.not.be.undefined
+        expect(reference.isWrite()).to.be.true
+        expect(reference.isRead()).to.be.false
+
+    it '"let a = 0;" should have a writable reference in function.', ->
+        ast = harmony.parse """
+        function foo() {
+            let a = 0;
+        }
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+        scope = scopeManager.scopes[1]
+        expect(scope.variables).to.have.length 2  # [arguments, a]
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.equal scope.variables[1]
+        expect(reference.writeExpr).to.not.be.undefined
+        expect(reference.isWrite()).to.be.true
+        expect(reference.isRead()).to.be.false
+
+    it '"const a = 0;" should have a writable reference on global.', ->
+        ast = harmony.parse """
+        const a = 0;
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 1
+
+        scope = scopeManager.scopes[0]
+        expect(scope.variables).to.have.length 1
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.equal scope.variables[0]
+        expect(reference.writeExpr).to.not.be.undefined
+        expect(reference.isWrite()).to.be.true
+        expect(reference.isRead()).to.be.false
+
+    it '"const a = 0;" should have a writable reference in function.', ->
+        ast = harmony.parse """
+        function foo() {
+            const a = 0;
+        }
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+        scope = scopeManager.scopes[1]
+        expect(scope.variables).to.have.length 2  # [arguments, a]
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.equal scope.variables[1]
+        expect(reference.writeExpr).to.not.be.undefined
+        expect(reference.isWrite()).to.be.true
+        expect(reference.isRead()).to.be.false
+
+    it '"var a = 0;" should not have references on global.', ->
+        ast = harmony.parse """
+        var a = 0;
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 1
+
+        scope = scopeManager.scopes[0]
+        expect(scope.variables).to.have.length 1
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.be.null  # the references of var declarations on global don't resolve because those are dynamic.
+        expect(reference.writeExpr).to.not.be.undefined
+        expect(reference.isWrite()).to.be.true
+        expect(reference.isRead()).to.be.false
+
+    it '"var a = 0;" should have a writable reference in function.', ->
+        ast = harmony.parse """
+        function foo() {
+            var a = 0;
+        }
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+        scope = scopeManager.scopes[1]
+        expect(scope.variables).to.have.length 2  # [arguments, a]
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.equal scope.variables[1]
+        expect(reference.writeExpr).to.not.be.undefined
+        expect(reference.isWrite()).to.be.true
+        expect(reference.isRead()).to.be.false
+
+    it '"function a() {} a();" should not have references on global.', ->
+        ast = harmony.parse """
+        function a() {}
+        a();
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2  # [global, a]
+
+        scope = scopeManager.scopes[0]
+        expect(scope.variables).to.have.length 1
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.be.null  # the references of var declarations on global don't resolve because those are dynamic.
+        expect(reference.isWrite()).to.be.false
+        expect(reference.isRead()).to.be.true
+
+    it '"function a() {} a();" should have a readable reference in function.', ->
+        ast = harmony.parse """
+        function foo() {
+            function a() {}
+            a();
+        }
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 3  # [global, foo, a]
+
+        scope = scopeManager.scopes[1]
+        expect(scope.variables).to.have.length 2  # [arguments, a]
+        expect(scope.references).to.have.length 1
+
+        reference = scope.references[0]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'a'
+        expect(reference.resolved).to.equal scope.variables[1]
+        expect(reference.isWrite()).to.be.false
+        expect(reference.isRead()).to.be.true
+
+    it '"class A {} new A();" should have a readable reference on global.', ->
+        ast = harmony.parse """
+        class A {}
+        let a = new A();
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2  # [global, A]
+
+        scope = scopeManager.scopes[0]
+        expect(scope.variables).to.have.length 2  # [A, a]
+        expect(scope.references).to.have.length 2  # [a, A]
+
+        reference = scope.references[1]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'A'
+        expect(reference.resolved).to.equal scope.variables[0]
+        expect(reference.isWrite()).to.be.false
+        expect(reference.isRead()).to.be.true
+
+    it '"class A {} new A();" should have a readable reference in function.', ->
+        ast = harmony.parse """
+        function foo() {
+            class A {}
+            let a = new A();
+        }
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 3 # [global, foo, A]
+
+        scope = scopeManager.scopes[1]
+        expect(scope.variables).to.have.length 3  # [arguments, A, a]
+        expect(scope.references).to.have.length 2  # [a, A]
+
+        reference = scope.references[1]
+        expect(reference.from).to.equal scope
+        expect(reference.identifier.name).to.equal 'A'
+        expect(reference.resolved).to.equal scope.variables[1]
+        expect(reference.isWrite()).to.be.false
+        expect(reference.isRead()).to.be.true
+
+# vim: set sw=4 ts=4 et tw=80 :

--- a/test/references.coffee
+++ b/test/references.coffee
@@ -26,214 +26,611 @@ harmony = require '../third_party/esprima'
 escope = require '..'
 
 describe 'References:', ->
-    it '"let a = 0;" should have a writable reference on global.', ->
-        ast = harmony.parse """
-        let a = 0;
-        """
-
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 1
-
-        scope = scopeManager.scopes[0]
-        expect(scope.variables).to.have.length 1
-        expect(scope.references).to.have.length 1
-
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.equal scope.variables[0]
-        expect(reference.writeExpr).to.not.be.undefined
-        expect(reference.isWrite()).to.be.true
-        expect(reference.isRead()).to.be.false
-
-    it '"let a = 0;" should have a writable reference in function.', ->
-        ast = harmony.parse """
-        function foo() {
+    describe 'When there is a `let` declaration on global,', ->
+        it 'the reference on global should be resolved.', ->
+            ast = harmony.parse """
             let a = 0;
-        }
-        """
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 1
 
-        scope = scopeManager.scopes[1]
-        expect(scope.variables).to.have.length 2  # [arguments, a]
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.equal scope.variables[1]
-        expect(reference.writeExpr).to.not.be.undefined
-        expect(reference.isWrite()).to.be.true
-        expect(reference.isRead()).to.be.false
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scope.variables[0]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
 
-    it '"const a = 0;" should have a writable reference on global.', ->
-        ast = harmony.parse """
-        const a = 0;
-        """
+        it 'the reference in functions should be resolved.', ->
+            ast = harmony.parse """
+            let a = 0;
+            function foo() {
+                let b = a;
+            }
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 1
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
 
-        scope = scopeManager.scopes[0]
-        expect(scope.variables).to.have.length 1
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.equal scope.variables[0]
-        expect(reference.writeExpr).to.not.be.undefined
-        expect(reference.isWrite()).to.be.true
-        expect(reference.isRead()).to.be.false
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
 
-    it '"const a = 0;" should have a writable reference in function.', ->
-        ast = harmony.parse """
-        function foo() {
+        it 'the reference in default parameters should be resolved.', ->
+            ast = harmony.parse """
+            let a = 0;
+            function foo(b = a) {
+            }
+            """
+
+            console.log(JSON.stringify(ast, null, 2))
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default values of destructuring should be resolved.', ->
+            ast = harmony.parse """
+            let a = 0;
+            function foo() {
+                let {b: a} = {};
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+    describe 'When there is a `const` declaration on global,', ->
+        it 'the reference on global should be resolved.', ->
+            ast = harmony.parse """
             const a = 0;
-        }
-        """
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 1
 
-        scope = scopeManager.scopes[1]
-        expect(scope.variables).to.have.length 2  # [arguments, a]
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.equal scope.variables[1]
-        expect(reference.writeExpr).to.not.be.undefined
-        expect(reference.isWrite()).to.be.true
-        expect(reference.isRead()).to.be.false
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scope.variables[0]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
 
-    it '"var a = 0;" should not have references on global.', ->
-        ast = harmony.parse """
-        var a = 0;
-        """
+        it 'the reference in functions should be resolved.', ->
+            ast = harmony.parse """
+            const a = 0;
+            function foo() {
+                const b = a;
+            }
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 1
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
 
-        scope = scopeManager.scopes[0]
-        expect(scope.variables).to.have.length 1
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.be.null  # the references of var declarations on global don't resolve because those are dynamic.
-        expect(reference.writeExpr).to.not.be.undefined
-        expect(reference.isWrite()).to.be.true
-        expect(reference.isRead()).to.be.false
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
 
-    it '"var a = 0;" should have a writable reference in function.', ->
-        ast = harmony.parse """
-        function foo() {
+        it 'the reference in default parameters should be resolved.', ->
+            ast = harmony.parse """
+            const a = 0;
+            function foo(b = a) {
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default values of destructuring should be resolved.', ->
+            ast = harmony.parse """
+            const a = 0;
+            function foo() {
+                const {b: a} = {};
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+    describe 'When there is a `var` declaration on global,', ->
+        it 'the reference on global should NOT be resolved.', ->
+            ast = harmony.parse """
             var a = 0;
-        }
-        """
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 1
 
-        scope = scopeManager.scopes[1]
-        expect(scope.variables).to.have.length 2  # [arguments, a]
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.equal scope.variables[1]
-        expect(reference.writeExpr).to.not.be.undefined
-        expect(reference.isWrite()).to.be.true
-        expect(reference.isRead()).to.be.false
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
 
-    it '"function a() {} a();" should not have references on global.', ->
-        ast = harmony.parse """
-        function a() {}
-        a();
-        """
+        it 'the reference in functions should NOT be resolved.', ->
+            ast = harmony.parse """
+            var a = 0;
+            function foo() {
+                var b = a;
+            }
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 2  # [global, a]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
 
-        scope = scopeManager.scopes[0]
-        expect(scope.variables).to.have.length 1
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.be.null  # the references of var declarations on global don't resolve because those are dynamic.
-        expect(reference.isWrite()).to.be.false
-        expect(reference.isRead()).to.be.true
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
 
-    it '"function a() {} a();" should have a readable reference in function.', ->
-        ast = harmony.parse """
-        function foo() {
+        it 'the reference in default parameters should NOT be resolved.', ->
+            ast = harmony.parse """
+            var a = 0;
+            function foo(b = a) {
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default values of destructuring should NOT be resolved.', ->
+            ast = harmony.parse """
+            var a = 0;
+            function foo() {
+                var {b: a} = {};
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+    describe 'When there is a `function` declaration on global,', ->
+        it 'the reference on global should NOT be resolved.', ->
+            ast = harmony.parse """
             function a() {}
             a();
-        }
-        """
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 3  # [global, foo, a]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, a]
 
-        scope = scopeManager.scopes[1]
-        expect(scope.variables).to.have.length 2  # [arguments, a]
-        expect(scope.references).to.have.length 1
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
 
-        reference = scope.references[0]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'a'
-        expect(reference.resolved).to.equal scope.variables[1]
-        expect(reference.isWrite()).to.be.false
-        expect(reference.isRead()).to.be.true
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
 
-    it '"class A {} new A();" should have a readable reference on global.', ->
-        ast = harmony.parse """
-        class A {}
-        let a = new A();
-        """
+        it 'the reference in functions should NOT be resolved.', ->
+            ast = harmony.parse """
+            function a() {}
+            function foo() {
+                let b = a();
+            }
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 2  # [global, A]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, a, foo]
 
-        scope = scopeManager.scopes[0]
-        expect(scope.variables).to.have.length 2  # [A, a]
-        expect(scope.references).to.have.length 2  # [a, A]
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
 
-        reference = scope.references[1]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'A'
-        expect(reference.resolved).to.equal scope.variables[0]
-        expect(reference.isWrite()).to.be.false
-        expect(reference.isRead()).to.be.true
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
 
-    it '"class A {} new A();" should have a readable reference in function.', ->
-        ast = harmony.parse """
-        function foo() {
+        it 'the reference in default parameters should NOT be resolved.', ->
+            ast = harmony.parse """
+            function a() {}
+            function foo(b = a()) {
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, a, foo]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default values of destructuring should NOT be resolved.', ->
+            ast = harmony.parse """
+            function a() {}
+            function foo() {
+                let {b: a()} = {};
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, a, foo]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.be.null
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+    describe 'When there is a `class` declaration on global,', ->
+        it 'the reference on global should be resolved.', ->
+            ast = harmony.parse """
             class A {}
-            let a = new A();
-        }
-        """
+            let b = new A();
+            """
 
-        scopeManager = escope.analyze ast, ecmaVersion: 6
-        expect(scopeManager.scopes).to.have.length 3 # [global, foo, A]
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, A]
 
-        scope = scopeManager.scopes[1]
-        expect(scope.variables).to.have.length 3  # [arguments, A, a]
-        expect(scope.references).to.have.length 2  # [a, A]
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 2  # [A, b]
+            expect(scope.references).to.have.length 2  # [b, A]
 
-        reference = scope.references[1]
-        expect(reference.from).to.equal scope
-        expect(reference.identifier.name).to.equal 'A'
-        expect(reference.resolved).to.equal scope.variables[1]
-        expect(reference.isWrite()).to.be.false
-        expect(reference.isRead()).to.be.true
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'A'
+            expect(reference.resolved).to.equal scope.variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in functions should be resolved.', ->
+            ast = harmony.parse """
+            class A {}
+            function foo() {
+                let b = new A();
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, A, foo]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, A]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'A'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default parameters should be resolved.', ->
+            ast = harmony.parse """
+            class A {}
+            function foo(b = new A()) {
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, A, foo]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, A]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'A'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default values of destructuring should be resolved.', ->
+            ast = harmony.parse """
+            class A {}
+            function foo() {
+                let {b: new A()} = {};
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, A, foo]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, A]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'A'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+    describe 'When there is a `let` declaration in functions,', ->
+        it 'the reference on the function should be resolved.', ->
+            ast = harmony.parse """
+            function foo() {
+                let a = 0;
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, a]
+            expect(scope.references).to.have.length 1
+
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scope.variables[1]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
+
+        it 'the reference in nested functions should be resolved.', ->
+            ast = harmony.parse """
+            function foo() {
+                let a = 0;
+                function bar() {
+                    let b = a;
+                }
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, foo, bar]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[1].variables[1]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default parameters body should be resolved.', ->
+            ast = harmony.parse """
+            function foo() {
+                let a = 0;
+                function bar(b = a) {
+                }
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, foo, bar]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[1].variables[1]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+        it 'the reference in default values of destructuring should be resolved.', ->
+            ast = harmony.parse """
+            function foo() {
+                let a = 0;
+                function bar() {
+                    let {b: a} = {};
+                }
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 3  # [global, foo, bar]
+
+            scope = scopeManager.scopes[2]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[1].variables[1]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
+    describe 'When there is a `let` declaration with destructuring assignment', ->
+        it '"let [a] = [1];", the reference should be resolved.', ->
+            ast = harmony.parse """
+            let [a] = [1];
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 1
+
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
+
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scope.variables[0]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
+
+        it '"let {a} = {a: 1};", the reference should be resolved.', ->
+            ast = harmony.parse """
+            let {a} = {a: 1};
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 1
+
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
+
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scope.variables[0]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
+
+        it '"let {a: {a}} = {a: {a: 1}};", the reference should be resolved.', ->
+            ast = harmony.parse """
+            let {a: {a}} = {a: {a: 1}};
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 1
+
+            scope = scopeManager.scopes[0]
+            expect(scope.variables).to.have.length 1
+            expect(scope.references).to.have.length 1
+
+            reference = scope.references[0]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scope.variables[0]
+            expect(reference.writeExpr).to.not.be.undefined
+            expect(reference.isWrite()).to.be.true
+            expect(reference.isRead()).to.be.false
 
 # vim: set sw=4 ts=4 et tw=80 :


### PR DESCRIPTION
References of `let`/`const`/`class` should be resolved
statically on the global scope also.

Related: #49 #56