### PR TITLE
Add references of default parameters and default values of destructuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "browserify": "^9.0.3",
     "chai": "^2.1.1",
     "coffee-script": "^1.9.1",
-    "espree": "^1.11.0",
+    "espree": "^2.0.2",
     "esprima": "^2.1.0",
     "gulp": "~3.8.10",
     "gulp-babel": "^4.0.0",

--- a/src/reference.js
+++ b/src/reference.js
@@ -31,7 +31,7 @@ const RW = READ | WRITE;
  * @class Reference
  */
 export default class Reference {
-    constructor(ident, scope, flag,  writeExpr, maybeImplicitGlobal, partial) {
+    constructor(ident, scope, flag,  writeExpr, maybeImplicitGlobal, partial, init) {
         /**
          * Identifier syntax node.
          * @member {esprima#Identifier} Reference#identifier
@@ -71,6 +71,11 @@ export default class Reference {
              * @member {boolean} Reference#partial
              */
             this.partial = partial;
+            /**
+             * Whether the Reference is to write of initialization.
+             * @member {boolean} Reference#init
+             */
+            this.init = init;
         }
         this.__maybeImplicitGlobal = maybeImplicitGlobal;
     }

--- a/src/referencer.js
+++ b/src/referencer.js
@@ -74,21 +74,15 @@ class PatternVisitor extends esrecurse.Visitor {
 
     AssignmentPattern(pattern) {
         this.assignments.push(pattern);
-        try {
-            this.visit(pattern.left);
-            this.rightHandNodes.push(pattern.right);
-        } finally {
-            this.assignments.pop();
-        }
+        this.visit(pattern.left);
+        this.rightHandNodes.push(pattern.right);
+        this.assignments.pop();
     }
 
     RestElement(pattern) {
         this.restElements.push(pattern);
-        try {
-            this.visit(pattern.argument);
-        } finally {
-            this.restElements.pop();
-        }
+        this.visit(pattern.argument);
+        this.restElements.pop();
     }
 
     MemberExpression(node) {
@@ -127,12 +121,9 @@ class PatternVisitor extends esrecurse.Visitor {
 
     AssignmentExpression(node) {
         this.assignments.push(node);
-        try {
-            this.visit(node.left);
-            this.rightHandNodes.push(node.right);
-        } finally {
-            this.assignments.pop();
-        }
+        this.visit(node.left);
+        this.rightHandNodes.push(node.right);
+        this.assignments.pop();
     }
 
     CallExpression(node) {

--- a/src/scope.js
+++ b/src/scope.js
@@ -344,7 +344,7 @@ export default class Scope {
         }
     }
 
-    __referencing(node, assign, writeExpr, maybeImplicitGlobal, partial) {
+    __referencing(node, assign, writeExpr, maybeImplicitGlobal, partial, init) {
         // because Array element may be null
         if (!node || node.type !== Syntax.Identifier) {
             return;
@@ -355,7 +355,7 @@ export default class Scope {
             return;
         }
 
-        let ref = new Reference(node, this, assign || Reference.READ, writeExpr, maybeImplicitGlobal, !!partial);
+        let ref = new Reference(node, this, assign || Reference.READ, writeExpr, maybeImplicitGlobal, !!partial, !!init);
         this.references.push(ref);
         this.__left.push(ref);
     }

--- a/test/es6-default-parameters.coffee
+++ b/test/es6-default-parameters.coffee
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+#  Copyright (C) 2015 Toru Nagashima
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+#  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+expect = require('chai').expect
+espree = require '../third_party/espree'
+escope = require '..'
+
+describe 'ES6 default parameters:', ->
+    describe 'a default parameter creates a writable reference for its initialization:', ->
+        patterns =
+            FunctionDeclaration: """
+                function foo(a, b = 0) {}
+            """
+            FunctionExpression: """
+                let foo = function(a, b = 0) {};
+            """
+            ArrowExpression: """
+                let foo = (a, b = 0) => {};
+            """
+
+        for name, code of patterns then do (name, code) ->
+            it name, ->
+                numVars = if name == 'ArrowExpression' then 2 else 3
+                ast = espree code
+
+                scopeManager = escope.analyze ast, ecmaVersion: 6
+                expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+                scope = scopeManager.scopes[1]
+                expect(scope.variables).to.have.length numVars  # [arguments?, a, b]
+                expect(scope.references).to.have.length 1
+
+                reference = scope.references[0]
+                expect(reference.from).to.equal scope
+                expect(reference.identifier.name).to.equal 'b'
+                expect(reference.resolved).to.equal scope.variables[numVars - 1]
+                expect(reference.writeExpr).to.not.be.undefined
+                expect(reference.isWrite()).to.be.true
+                expect(reference.isRead()).to.be.false
+
+    describe 'a default parameter creates a readable reference for references in right:', ->
+        patterns =
+            FunctionDeclaration: """
+                let a;
+                function foo(b = a) {}
+            """
+            FunctionExpression: """
+                let a;
+                let foo = function(b = a) {}
+            """
+            ArrowExpression: """
+                let a;
+                let foo = (b = a) => {};
+            """
+
+        for name, code of patterns then do (name, code) ->
+            it name, ->
+                numVars = if name == 'ArrowExpression' then 1 else 2
+                ast = espree code
+
+                scopeManager = escope.analyze ast, ecmaVersion: 6
+                expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+                scope = scopeManager.scopes[1]
+                expect(scope.variables).to.have.length numVars  # [arguments?, b]
+                expect(scope.references).to.have.length 2  # [b, a]
+
+                reference = scope.references[1]
+                expect(reference.from).to.equal scope
+                expect(reference.identifier.name).to.equal 'a'
+                expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+                expect(reference.writeExpr).to.be.undefined
+                expect(reference.isWrite()).to.be.false
+                expect(reference.isRead()).to.be.true
+
+    describe 'a default parameter creates a readable reference for references in right (for const):', ->
+        patterns =
+            FunctionDeclaration: """
+                const a = 0;
+                function foo(b = a) {}
+            """
+            FunctionExpression: """
+                const a = 0;
+                let foo = function(b = a) {}
+            """
+            ArrowExpression: """
+                const a = 0;
+                let foo = (b = a) => {};
+            """
+
+        for name, code of patterns then do (name, code) ->
+            it name, ->
+                numVars = if name == 'ArrowExpression' then 1 else 2
+                ast = espree code
+
+                scopeManager = escope.analyze ast, ecmaVersion: 6
+                expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+                scope = scopeManager.scopes[1]
+                expect(scope.variables).to.have.length numVars  # [arguments?, b]
+                expect(scope.references).to.have.length 2  # [b, a]
+
+                reference = scope.references[1]
+                expect(reference.from).to.equal scope
+                expect(reference.identifier.name).to.equal 'a'
+                expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+                expect(reference.writeExpr).to.be.undefined
+                expect(reference.isWrite()).to.be.false
+                expect(reference.isRead()).to.be.true
+
+    describe 'a default parameter creates a readable reference for references in right (partial):', ->
+        patterns =
+            FunctionDeclaration: """
+                let a;
+                function foo(b = a.c) {}
+            """
+            FunctionExpression: """
+                let a;
+                let foo = function(b = a.c) {}
+            """
+            ArrowExpression: """
+                let a;
+                let foo = (b = a.c) => {};
+            """
+
+        for name, code of patterns then do (name, code) ->
+            it name, ->
+                numVars = if name == 'ArrowExpression' then 1 else 2
+                ast = espree code
+
+                scopeManager = escope.analyze ast, ecmaVersion: 6
+                expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+                scope = scopeManager.scopes[1]
+                expect(scope.variables).to.have.length numVars  # [arguments?, b]
+                expect(scope.references).to.have.length 2  # [b, a]
+
+                reference = scope.references[1]
+                expect(reference.from).to.equal scope
+                expect(reference.identifier.name).to.equal 'a'
+                expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+                expect(reference.writeExpr).to.be.undefined
+                expect(reference.isWrite()).to.be.false
+                expect(reference.isRead()).to.be.true
+
+    describe 'a default parameter creates a readable reference for references in right\'s nested scope:', ->
+        patterns =
+            FunctionDeclaration: """
+                let a;
+                function foo(b = function() { return a; }) {}
+            """
+            FunctionExpression: """
+                let a;
+                let foo = function(b = function() { return a; }) {}
+            """
+            ArrowExpression: """
+                let a;
+                let foo = (b = function() { return a; }) => {};
+            """
+
+        for name, code of patterns then do (name, code) ->
+            it name, ->
+                ast = espree code
+
+                scopeManager = escope.analyze ast, ecmaVersion: 6
+                expect(scopeManager.scopes).to.have.length 3  # [global, foo, anonymous]
+
+                scope = scopeManager.scopes[2]
+                expect(scope.variables).to.have.length 1  # [arguments]
+                expect(scope.references).to.have.length 1  # [a]
+
+                reference = scope.references[0]
+                expect(reference.from).to.equal scope
+                expect(reference.identifier.name).to.equal 'a'
+                expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+                expect(reference.writeExpr).to.be.undefined
+                expect(reference.isWrite()).to.be.false
+                expect(reference.isRead()).to.be.true
+
+# vim: set sw=4 ts=4 et tw=80 :

--- a/test/es6-destructuring-assignments.coffee
+++ b/test/es6-destructuring-assignments.coffee
@@ -68,6 +68,400 @@ describe 'ES6 destructuring assignments', ->
         expect(scope.references[3].identifier.name).to.be.equal 'array'
         expect(scope.references[3].isWrite()).to.be.false
 
+    it 'Pattern in let in ForInStatement', ->
+        ast = harmony.parse """
+        (function () {
+            for (let [a, b, c] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 4  # [global, function, TDZ, for]
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 1
+        expect(scope.implicit.left[0].identifier.name).to.equal 'array'
+
+        scope = scopeManager.scopes[2]
+        expect(scope.type).to.equal 'TDZ'
+        expect(scope.variables).to.have.length 3
+        expect(scope.variables[0].name).to.equal 'a'
+        expect(scope.variables[1].name).to.equal 'b'
+        expect(scope.variables[2].name).to.equal 'c'
+        expect(scope.references).to.have.length 1
+        expect(scope.references[0].identifier.name).to.equal 'array'
+        expect(scope.references[0].isWrite()).to.be.false
+
+        scope = scopeManager.scopes[3]
+        expect(scope.type).to.equal 'for'
+        expect(scope.variables).to.have.length 3
+        expect(scope.variables[0].name).to.equal 'a'
+        expect(scope.variables[1].name).to.equal 'b'
+        expect(scope.variables[2].name).to.equal 'c'
+        expect(scope.references).to.have.length 3
+        expect(scope.references[0].identifier.name).to.equal 'a'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].partial).to.be.true
+        expect(scope.references[0].resolved).to.equal scope.variables[0]
+        expect(scope.references[1].identifier.name).to.equal 'b'
+        expect(scope.references[1].isWrite()).to.be.true
+        expect(scope.references[1].partial).to.be.true
+        expect(scope.references[1].resolved).to.equal scope.variables[1]
+        expect(scope.references[2].identifier.name).to.equal 'c'
+        expect(scope.references[2].isWrite()).to.be.true
+        expect(scope.references[2].partial).to.be.true
+        expect(scope.references[2].resolved).to.equal scope.variables[2]
+
+    it 'Pattern with default values in var in ForInStatement', ->
+        ast = espree """
+        (function () {
+            for (var [a, b, c = d] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 2
+        expect(scope.implicit.left[0].identifier.name).to.equal 'd'
+        expect(scope.implicit.left[1].identifier.name).to.equal 'array'
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 4
+        expect(scope.variables[0].name).to.equal 'arguments'
+        expect(scope.variables[1].name).to.equal 'a'
+        expect(scope.variables[2].name).to.equal 'b'
+        expect(scope.variables[3].name).to.equal 'c'
+        expect(scope.references).to.have.length 6
+        expect(scope.references[0].identifier.name).to.equal 'c'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].writeExpr.name).to.equal 'd'
+        expect(scope.references[0].partial).to.be.false
+        expect(scope.references[0].resolved).to.equal scope.variables[3]
+        expect(scope.references[1].identifier.name).to.equal 'd'
+        expect(scope.references[1].isWrite()).to.be.false
+        expect(scope.references[2].identifier.name).to.equal 'a'
+        expect(scope.references[2].isWrite()).to.be.true
+        expect(scope.references[2].partial).to.be.true
+        expect(scope.references[2].resolved).to.equal scope.variables[1]
+        expect(scope.references[3].identifier.name).to.equal 'b'
+        expect(scope.references[3].isWrite()).to.be.true
+        expect(scope.references[3].partial).to.be.true
+        expect(scope.references[3].resolved).to.equal scope.variables[2]
+        expect(scope.references[4].identifier.name).to.equal 'c'
+        expect(scope.references[4].isWrite()).to.be.true
+        expect(scope.references[4].writeExpr.name).to.equal 'array'
+        expect(scope.references[4].partial).to.be.true
+        expect(scope.references[4].resolved).to.equal scope.variables[3]
+        expect(scope.references[5].identifier.name).to.equal 'array'
+        expect(scope.references[5].isWrite()).to.be.false
+
+    it 'Pattern with default values in let in ForInStatement', ->
+        ast = espree """
+        (function () {
+            for (let [a, b, c = d] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 4  # [global, function, TDZ, for]
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 2
+        expect(scope.implicit.left[0].identifier.name).to.equal 'array'
+        expect(scope.implicit.left[0].from.type).to.equal 'TDZ'
+        expect(scope.implicit.left[1].identifier.name).to.equal 'd'
+        expect(scope.implicit.left[1].from.type).to.equal 'for'
+
+        scope = scopeManager.scopes[2]
+        expect(scope.type).to.equal 'TDZ'
+        expect(scope.variables).to.have.length 3
+        expect(scope.variables[0].name).to.equal 'a'
+        expect(scope.variables[1].name).to.equal 'b'
+        expect(scope.variables[2].name).to.equal 'c'
+        expect(scope.references).to.have.length 1
+        expect(scope.references[0].identifier.name).to.equal 'array'
+        expect(scope.references[0].isWrite()).to.be.false
+
+        scope = scopeManager.scopes[3]
+        expect(scope.type).to.equal 'for'
+        expect(scope.variables).to.have.length 3
+        expect(scope.variables[0].name).to.equal 'a'
+        expect(scope.variables[1].name).to.equal 'b'
+        expect(scope.variables[2].name).to.equal 'c'
+        expect(scope.references).to.have.length 5
+        expect(scope.references[0].identifier.name).to.equal 'c'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].writeExpr.name).to.equal 'd'
+        expect(scope.references[0].partial).to.be.false
+        expect(scope.references[0].resolved).to.equal scope.variables[2]
+        expect(scope.references[1].identifier.name).to.equal 'd'
+        expect(scope.references[1].isWrite()).to.be.false
+        expect(scope.references[2].identifier.name).to.equal 'a'
+        expect(scope.references[2].isWrite()).to.be.true
+        expect(scope.references[2].writeExpr.name).to.equal 'array'
+        expect(scope.references[2].partial).to.be.true
+        expect(scope.references[2].resolved).to.equal scope.variables[0]
+        expect(scope.references[3].identifier.name).to.equal 'b'
+        expect(scope.references[3].isWrite()).to.be.true
+        expect(scope.references[3].writeExpr.name).to.equal 'array'
+        expect(scope.references[3].partial).to.be.true
+        expect(scope.references[3].resolved).to.equal scope.variables[1]
+        expect(scope.references[4].identifier.name).to.equal 'c'
+        expect(scope.references[4].isWrite()).to.be.true
+        expect(scope.references[4].writeExpr.name).to.equal 'array'
+        expect(scope.references[4].partial).to.be.true
+        expect(scope.references[4].resolved).to.equal scope.variables[2]
+
+    it 'Pattern with nested default values in var in ForInStatement', ->
+        ast = espree """
+        (function () {
+            for (var [a, [b, c = d] = e] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 3
+        expect(scope.implicit.left[0].identifier.name).to.equal 'd'
+        expect(scope.implicit.left[1].identifier.name).to.equal 'e'
+        expect(scope.implicit.left[2].identifier.name).to.equal 'array'
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 4
+        expect(scope.variables[0].name).to.equal 'arguments'
+        expect(scope.variables[1].name).to.equal 'a'
+        expect(scope.variables[2].name).to.equal 'b'
+        expect(scope.variables[3].name).to.equal 'c'
+        expect(scope.references).to.have.length 9
+        expect(scope.references[0].identifier.name).to.equal 'b'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].writeExpr.name).to.equal 'e'
+        expect(scope.references[0].partial).to.be.true
+        expect(scope.references[0].resolved).to.equal scope.variables[2]
+        expect(scope.references[1].identifier.name).to.equal 'c'
+        expect(scope.references[1].isWrite()).to.be.true
+        expect(scope.references[1].writeExpr.name).to.equal 'e'
+        expect(scope.references[1].partial).to.be.true
+        expect(scope.references[1].resolved).to.equal scope.variables[3]
+        expect(scope.references[2].identifier.name).to.equal 'c'
+        expect(scope.references[2].isWrite()).to.be.true
+        expect(scope.references[2].writeExpr.name).to.equal 'd'
+        expect(scope.references[2].partial).to.be.false
+        expect(scope.references[2].resolved).to.equal scope.variables[3]
+        expect(scope.references[3].identifier.name).to.equal 'd'
+        expect(scope.references[3].isWrite()).to.be.false
+        expect(scope.references[4].identifier.name).to.equal 'e'
+        expect(scope.references[4].isWrite()).to.be.false
+        expect(scope.references[5].identifier.name).to.equal 'a'
+        expect(scope.references[5].isWrite()).to.be.true
+        expect(scope.references[5].writeExpr.name).to.equal 'array'
+        expect(scope.references[5].partial).to.be.true
+        expect(scope.references[5].resolved).to.equal scope.variables[1]
+        expect(scope.references[6].identifier.name).to.equal 'b'
+        expect(scope.references[6].isWrite()).to.be.true
+        expect(scope.references[6].writeExpr.name).to.equal 'array'
+        expect(scope.references[6].partial).to.be.true
+        expect(scope.references[6].resolved).to.equal scope.variables[2]
+        expect(scope.references[7].identifier.name).to.equal 'c'
+        expect(scope.references[7].isWrite()).to.be.true
+        expect(scope.references[7].writeExpr.name).to.equal 'array'
+        expect(scope.references[7].partial).to.be.true
+        expect(scope.references[7].resolved).to.equal scope.variables[3]
+        expect(scope.references[8].identifier.name).to.equal 'array'
+        expect(scope.references[8].isWrite()).to.be.false
+
+    it 'Pattern with nested default values in let in ForInStatement', ->
+        ast = espree """
+        (function () {
+            for (let [a, [b, c = d] = e] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 4  # [global, function, TDZ, for]
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 3
+        expect(scope.implicit.left[0].identifier.name).to.equal 'array'
+        expect(scope.implicit.left[0].from.type).to.equal 'TDZ'
+        expect(scope.implicit.left[1].identifier.name).to.equal 'd'
+        expect(scope.implicit.left[1].from.type).to.equal 'for'
+        expect(scope.implicit.left[2].identifier.name).to.equal 'e'
+        expect(scope.implicit.left[2].from.type).to.equal 'for'
+
+        scope = scopeManager.scopes[2]
+        expect(scope.type).to.equal 'TDZ'
+        expect(scope.variables).to.have.length 3
+        expect(scope.variables[0].name).to.equal 'a'
+        expect(scope.variables[1].name).to.equal 'b'
+        expect(scope.variables[2].name).to.equal 'c'
+        expect(scope.references).to.have.length 1
+        expect(scope.references[0].identifier.name).to.equal 'array'
+        expect(scope.references[0].isWrite()).to.be.false
+
+        scope = scopeManager.scopes[3]
+        expect(scope.type).to.equal 'for'
+        expect(scope.variables).to.have.length 3
+        expect(scope.variables[0].name).to.equal 'a'
+        expect(scope.variables[1].name).to.equal 'b'
+        expect(scope.variables[2].name).to.equal 'c'
+        expect(scope.references).to.have.length 8
+        expect(scope.references[0].identifier.name).to.equal 'b'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].writeExpr.name).to.equal 'e'
+        expect(scope.references[0].partial).to.be.true
+        expect(scope.references[0].resolved).to.equal scope.variables[1]
+        expect(scope.references[1].identifier.name).to.equal 'c'
+        expect(scope.references[1].isWrite()).to.be.true
+        expect(scope.references[1].writeExpr.name).to.equal 'e'
+        expect(scope.references[1].partial).to.be.true
+        expect(scope.references[1].resolved).to.equal scope.variables[2]
+        expect(scope.references[2].identifier.name).to.equal 'c'
+        expect(scope.references[2].isWrite()).to.be.true
+        expect(scope.references[2].writeExpr.name).to.equal 'd'
+        expect(scope.references[2].partial).to.be.false
+        expect(scope.references[2].resolved).to.equal scope.variables[2]
+        expect(scope.references[3].identifier.name).to.equal 'd'
+        expect(scope.references[3].isWrite()).to.be.false
+        expect(scope.references[4].identifier.name).to.equal 'e'
+        expect(scope.references[4].isWrite()).to.be.false
+        expect(scope.references[5].identifier.name).to.equal 'a'
+        expect(scope.references[5].isWrite()).to.be.true
+        expect(scope.references[5].writeExpr.name).to.equal 'array'
+        expect(scope.references[5].partial).to.be.true
+        expect(scope.references[5].resolved).to.equal scope.variables[0]
+        expect(scope.references[6].identifier.name).to.equal 'b'
+        expect(scope.references[6].isWrite()).to.be.true
+        expect(scope.references[6].writeExpr.name).to.equal 'array'
+        expect(scope.references[6].partial).to.be.true
+        expect(scope.references[6].resolved).to.equal scope.variables[1]
+        expect(scope.references[7].identifier.name).to.equal 'c'
+        expect(scope.references[7].isWrite()).to.be.true
+        expect(scope.references[7].writeExpr.name).to.equal 'array'
+        expect(scope.references[7].partial).to.be.true
+        expect(scope.references[7].resolved).to.equal scope.variables[2]
+
+    it 'Pattern with default values in var in ForInStatement (separate declarations)', ->
+        ast = espree """
+        (function () {
+            var a, b, c;
+            for ([a, b, c = d] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 2
+        expect(scope.implicit.left[0].identifier.name).to.equal 'd'
+        expect(scope.implicit.left[1].identifier.name).to.equal 'array'
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 4
+        expect(scope.variables[0].name).to.equal 'arguments'
+        expect(scope.variables[1].name).to.equal 'a'
+        expect(scope.variables[2].name).to.equal 'b'
+        expect(scope.variables[3].name).to.equal 'c'
+        expect(scope.references).to.have.length 6
+        expect(scope.references[0].identifier.name).to.equal 'a'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].partial).to.be.true
+        expect(scope.references[0].resolved).to.equal scope.variables[1]
+        expect(scope.references[1].identifier.name).to.equal 'b'
+        expect(scope.references[1].isWrite()).to.be.true
+        expect(scope.references[1].partial).to.be.true
+        expect(scope.references[1].resolved).to.equal scope.variables[2]
+        expect(scope.references[2].identifier.name).to.equal 'c'
+        expect(scope.references[2].isWrite()).to.be.true
+        expect(scope.references[2].writeExpr.name).to.equal 'd'
+        expect(scope.references[2].partial).to.be.false
+        expect(scope.references[2].resolved).to.equal scope.variables[3]
+        expect(scope.references[3].identifier.name).to.equal 'c'
+        expect(scope.references[3].isWrite()).to.be.true
+        expect(scope.references[3].writeExpr.name).to.equal 'array'
+        expect(scope.references[3].partial).to.be.true
+        expect(scope.references[3].resolved).to.equal scope.variables[3]
+        expect(scope.references[4].identifier.name).to.equal 'd'
+        expect(scope.references[4].isWrite()).to.be.false
+        expect(scope.references[5].identifier.name).to.equal 'array'
+        expect(scope.references[5].isWrite()).to.be.false
+
+    it 'Pattern with default values in var in ForInStatement (separate declarations and with MemberExpression)', ->
+        ast = espree """
+        (function () {
+            var obj;
+            for ([obj.a, obj.b, obj.c = d] in array);
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 2
+        expect(scope.implicit.left[0].identifier.name).to.equal 'd'
+        expect(scope.implicit.left[1].identifier.name).to.equal 'array'
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 2
+        expect(scope.variables[0].name).to.equal 'arguments'
+        expect(scope.variables[1].name).to.equal 'obj'
+        expect(scope.references).to.have.length 5
+        expect(scope.references[0].identifier.name).to.equal 'obj'  # obj.a
+        expect(scope.references[0].isWrite()).to.be.false
+        expect(scope.references[0].isRead()).to.be.true
+        expect(scope.references[0].resolved).to.equal scope.variables[1]
+        expect(scope.references[1].identifier.name).to.equal 'obj'  # obj.b
+        expect(scope.references[1].isWrite()).to.be.false
+        expect(scope.references[1].isRead()).to.be.true
+        expect(scope.references[1].resolved).to.equal scope.variables[1]
+        expect(scope.references[2].identifier.name).to.equal 'obj'  # obj.c
+        expect(scope.references[2].isWrite()).to.be.false
+        expect(scope.references[2].isRead()).to.be.true
+        expect(scope.references[2].resolved).to.equal scope.variables[1]
+        expect(scope.references[3].identifier.name).to.equal 'd'
+        expect(scope.references[3].isWrite()).to.be.false
+        expect(scope.references[3].isRead()).to.be.true
+        expect(scope.references[4].identifier.name).to.equal 'array'
+        expect(scope.references[4].isWrite()).to.be.false
+        expect(scope.references[4].isRead()).to.be.true
 
     it 'ArrayPattern in var', ->
         ast = harmony.parse """
@@ -340,6 +734,47 @@ describe 'ES6 destructuring assignments', ->
         expect(scope.references[3].identifier.name).to.be.equal 'array'
         expect(scope.references[3].isWrite()).to.be.false
 
+    it 'ArrayPattern with MemberExpression in AssignmentExpression', ->
+        ast = harmony.parse """
+        (function () {
+            var obj;
+            [obj.a, obj.b, obj.c] = array;
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 1
+        expect(scope.implicit.left[0].identifier.name).to.equal 'array'
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 2
+        expect(scope.variables[0].name).to.equal 'arguments'
+        expect(scope.variables[1].name).to.equal 'obj'
+        expect(scope.references).to.have.length 4
+        expect(scope.references[0].identifier.name).to.equal 'obj'
+        expect(scope.references[0].isWrite()).to.be.false
+        expect(scope.references[0].isRead()).to.be.true
+        expect(scope.references[0].resolved).to.equal scope.variables[1]
+        expect(scope.references[1].identifier.name).to.equal 'obj'
+        expect(scope.references[1].isWrite()).to.be.false
+        expect(scope.references[1].isRead()).to.be.true
+        expect(scope.references[1].resolved).to.equal scope.variables[1]
+        expect(scope.references[2].identifier.name).to.equal 'obj'
+        expect(scope.references[2].isWrite()).to.be.false
+        expect(scope.references[2].isRead()).to.be.true
+        expect(scope.references[2].resolved).to.equal scope.variables[1]
+        expect(scope.references[3].identifier.name).to.equal 'array'
+        expect(scope.references[3].isWrite()).to.be.false
+        expect(scope.references[3].isRead()).to.be.true
+
     it 'SpreadElement in AssignmentExpression', ->
         ast = harmony.parse """
         (function () {
@@ -427,6 +862,47 @@ describe 'ES6 destructuring assignments', ->
             expect(scope.references[index].resolved).to.be.null
         expect(scope.references[5].identifier.name).to.be.equal 'array'
         expect(scope.references[5].isWrite()).to.be.false
+
+    it 'SpreadElement with MemberExpression in AssignmentExpression', ->
+        ast = harmony.parse """
+        (function () {
+            [a, b, ...obj.rest] = array;
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+        expect(scope.implicit.left).to.have.length 4
+        expect(scope.implicit.left.map((ref) => ref.identifier.name)).to.deep.equal [
+            'a'
+            'b'
+            'obj'
+            'array'
+        ]
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 1
+        expect(scope.variables[0].name).to.equal 'arguments'
+        expect(scope.references).to.have.length 4
+        expect(scope.references[0].identifier.name).to.equal 'a'
+        expect(scope.references[0].isWrite()).to.be.true
+        expect(scope.references[0].partial).to.be.true
+        expect(scope.references[0].resolved).to.be.null
+        expect(scope.references[1].identifier.name).to.equal 'b'
+        expect(scope.references[1].isWrite()).to.be.true
+        expect(scope.references[1].partial).to.be.true
+        expect(scope.references[1].resolved).to.be.null
+        expect(scope.references[2].identifier.name).to.equal 'obj'
+        expect(scope.references[2].isWrite()).to.be.false
+        expect(scope.references[3].identifier.name).to.equal 'array'
+        expect(scope.references[3].isWrite()).to.be.false
 
     it 'ObjectPattern in AssignmentExpression', ->
         ast = harmony.parse """
@@ -731,12 +1207,13 @@ describe 'ES6 destructuring assignments', ->
                 'd'
             ]
             expect(scope.variables[index].name).to.be.equal name
-        expect(scope.references).to.have.length 5
+        expect(scope.references).to.have.length 6
         for name, index in [
                 'a'
                 'b'
                 'c'
-                'd'
+                'd' # assign 20
+                'd' # assign array
                 'array'
             ]
             expect(scope.references[index].identifier.name).to.be.equal name
@@ -768,15 +1245,58 @@ describe 'ES6 destructuring assignments', ->
                 'd'
             ]
             expect(scope.variables[index].name).to.be.equal name
-        expect(scope.references).to.have.length 6
+        expect(scope.references).to.have.length 7
         for name, index in [
-                'a'
-                'b'
-                'c'
-                'd'
+                'a' # assign array
+                'b' # assign array
+                'c' # assign array
+                'd' # assign e
+                'd' # assign array
                 'e'
                 'array'
             ]
             expect(scope.references[index].identifier.name).to.be.equal name
+
+    it 'nested default values containing references and patterns in var', ->
+        ast = espree """
+        (function () {
+            var [a, b, [c, d = e] = f ] = array;
+        }());
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        globalScope = scope
+        expect(scope.type).to.equal 'global'
+        expect(scope.variables).to.have.length 0
+        expect(scope.references).to.have.length 0
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.equal 'function'
+        expect(scope.variables).to.have.length 5
+        for name, index in [
+                'arguments'
+                'a'
+                'b'
+                'c'
+                'd'
+            ]
+            expect(scope.variables[index].name).to.equal name
+        expect(scope.references).to.have.length 10
+        for name, index in [
+                'a' # assign array
+                'b' # assign array
+                'c' # assign f
+                'c' # assign array
+                'd' # assign f
+                'd' # assign e
+                'd' # assign array
+                'e'
+                'f'
+                'array'
+            ]
+            expect(scope.references[index].identifier.name).to.equal name
 
 # vim: set sw=4 ts=4 et tw=80 :

--- a/test/es6-rest-args.coffee
+++ b/test/es6-rest-args.coffee
@@ -23,11 +23,36 @@
 
 expect = require('chai').expect
 harmony = require '../third_party/esprima'
+espree = require '../third_party/espree'
 escope = require '..'
 
 describe 'ES6 rest arguments', ->
-    it 'materialize rest argument in scope', ->
+    it 'materialize rest argument in scope (esprima: rest property of FunctionDeclaration)', ->
         ast = harmony.parse """
+        function foo(...bar) {
+            return bar;
+        }
+        """
+
+        scopeManager = escope.analyze ast, ecmaVersion: 6
+        expect(scopeManager.scopes).to.have.length 2
+
+        scope = scopeManager.scopes[0]
+        expect(scope.type).to.be.equal 'global'
+        expect(scope.block.type).to.be.equal 'Program'
+        expect(scope.isStrict).to.be.false
+        expect(scope.variables).to.have.length 1
+
+        scope = scopeManager.scopes[1]
+        expect(scope.type).to.be.equal 'function'
+        expect(scope.variables).to.have.length 2
+        expect(scope.variables[0].name).to.be.equal 'arguments'
+        expect(scope.variables[1].name).to.be.equal 'bar'
+        expect(scope.variables[1].defs[0].name.name).to.be.equal 'bar'
+        expect(scope.variables[1].defs[0].rest).to.be.true
+
+    it 'materialize rest argument in scope (espree: RestElement)', ->
+        ast = espree """
         function foo(...bar) {
             return bar;
         }

--- a/test/references.coffee
+++ b/test/references.coffee
@@ -22,13 +22,13 @@
 #  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 expect = require('chai').expect
-harmony = require '../third_party/esprima'
+espree = require '../third_party/espree'
 escope = require '..'
 
 describe 'References:', ->
     describe 'When there is a `let` declaration on global,', ->
         it 'the reference on global should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             let a = 0;
             """
 
@@ -48,7 +48,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it 'the reference in functions should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             let a = 0;
             function foo() {
                 let b = a;
@@ -70,9 +70,31 @@ describe 'References:', ->
             expect(reference.isWrite()).to.be.false
             expect(reference.isRead()).to.be.true
 
+        it 'the reference in default parameters should be resolved.', ->
+            ast = espree """
+            let a = 0;
+            function foo(b = a) {
+            }
+            """
+
+            scopeManager = escope.analyze ast, ecmaVersion: 6
+            expect(scopeManager.scopes).to.have.length 2  # [global, foo]
+
+            scope = scopeManager.scopes[1]
+            expect(scope.variables).to.have.length 2  # [arguments, b]
+            expect(scope.references).to.have.length 2  # [b, a]
+
+            reference = scope.references[1]
+            expect(reference.from).to.equal scope
+            expect(reference.identifier.name).to.equal 'a'
+            expect(reference.resolved).to.equal scopeManager.scopes[0].variables[0]
+            expect(reference.writeExpr).to.be.undefined
+            expect(reference.isWrite()).to.be.false
+            expect(reference.isRead()).to.be.true
+
     describe 'When there is a `const` declaration on global,', ->
         it 'the reference on global should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             const a = 0;
             """
 
@@ -92,7 +114,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it 'the reference in functions should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             const a = 0;
             function foo() {
                 const b = a;
@@ -116,7 +138,7 @@ describe 'References:', ->
 
     describe 'When there is a `var` declaration on global,', ->
         it 'the reference on global should NOT be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             var a = 0;
             """
 
@@ -136,7 +158,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it 'the reference in functions should NOT be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             var a = 0;
             function foo() {
                 var b = a;
@@ -160,7 +182,7 @@ describe 'References:', ->
 
     describe 'When there is a `function` declaration on global,', ->
         it 'the reference on global should NOT be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             function a() {}
             a();
             """
@@ -181,7 +203,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.true
 
         it 'the reference in functions should NOT be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             function a() {}
             function foo() {
                 let b = a();
@@ -205,7 +227,7 @@ describe 'References:', ->
 
     describe 'When there is a `class` declaration on global,', ->
         it 'the reference on global should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             class A {}
             let b = new A();
             """
@@ -226,7 +248,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.true
 
         it 'the reference in functions should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             class A {}
             function foo() {
                 let b = new A();
@@ -250,7 +272,7 @@ describe 'References:', ->
 
     describe 'When there is a `let` declaration in functions,', ->
         it 'the reference on the function should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             function foo() {
                 let a = 0;
             }
@@ -272,7 +294,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it 'the reference in nested functions should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             function foo() {
                 let a = 0;
                 function bar() {
@@ -298,7 +320,7 @@ describe 'References:', ->
 
     describe 'When there is a `var` declaration in functions,', ->
         it 'the reference on the function should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             function foo() {
                 var a = 0;
             }
@@ -320,7 +342,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it 'the reference in nested functions should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             function foo() {
                 var a = 0;
                 function bar() {
@@ -346,7 +368,7 @@ describe 'References:', ->
 
     describe 'When there is a `let` declaration with destructuring assignment', ->
         it '"let [a] = [1];", the reference should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             let [a] = [1];
             """
 
@@ -366,7 +388,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it '"let {a} = {a: 1};", the reference should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             let {a} = {a: 1};
             """
 
@@ -386,7 +408,7 @@ describe 'References:', ->
             expect(reference.isRead()).to.be.false
 
         it '"let {a: {a}} = {a: {a: 1}};", the reference should be resolved.', ->
-            ast = harmony.parse """
+            ast = espree """
             let {a: {a}} = {a: {a: 1}};
             """
 


### PR DESCRIPTION
Hello.

I tried to implement default parameters and default values of destructuring assignments.

- Mainly, I changed `PatternVisitor` to collect right-hand nodes (readonly subtrees). At `Referencer.visitPattern`'s last, visits the right-hand nodes recursively. This logic adds readable references for identifiers in default values.
- `Referencer.referencingDefaultValue` adds writable references for parameters/variables that has its default value. the references are similar to references of `VariableDeclarator.init`. Patterns can be nested, can have multiple default values, so it might need an utility such as `Reference.isInit`.
- I added options (processing right-hand nodes or not) to `Referencer.visitPattern`, because there are calling `Referencer.visitPattern` twice for same nodes.

Thanks!

Note: [this error](https://github.com/estools/escope/pull/61#issuecomment-100251612) has been occurring on this PR version. Umm...