### PR TITLE
Feature Request: getDeclaredVariables(node): Variables[]

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -50,6 +50,7 @@ export default class ScopeManager {
         this.__nodeToScope = new WeakMap();
         this.__currentScope = null;
         this.__options = options;
+        this.__declaredVariables = new WeakMap();
     }
 
     __useDirective() {
@@ -75,6 +76,19 @@ export default class ScopeManager {
     // Returns appropliate scope for this node.
     __get(node) {
         return this.__nodeToScope.get(node);
+    }
+
+    /**
+     * Get variables that are declared by the node.
+     *
+     * "are declared by the node" means the node is same as `Variable.defs[].node` or `Variable.defs[].parent`.
+     * If the node declares nothing, this method returns an empty array.
+     *
+     * @param {Esprima.Node} node - a node to get.
+     * @returns {Variable[]} variables that declared by the node.
+     */
+    getDeclaredVariables(node) {
+        return this.__declaredVariables.get(node) || [];
     }
 
     /**

--- a/src/scope.js
+++ b/src/scope.js
@@ -227,6 +227,8 @@ export default class Scope {
             this.upper.childScopes.push(this);
         }
 
+        this.__declaredVariables = scopeManager.__declaredVariables;
+
         registerScope(scopeManager, this);
     }
 
@@ -315,6 +317,19 @@ export default class Scope {
         this.through.push(ref);
     }
 
+    __addDeclaredVariablesOfNode(variable, node) {
+        if (node == null) {
+            return;
+        }
+
+        var variables = this.__declaredVariables.get(node);
+        if (variables == null) {
+            variables = [];
+            this.__declaredVariables.set(node, variables);
+        }
+        variables.push(variable);
+    }
+
     __defineGeneric(name, set, variables, node, def) {
         var variable;
 
@@ -327,6 +342,10 @@ export default class Scope {
 
         if (def) {
             variable.defs.push(def);
+            if (def.type !== Variable.TDZ) {
+                this.__addDeclaredVariablesOfNode(variable, def.node);
+                this.__addDeclaredVariablesOfNode(variable, def.parent);
+            }
         }
         if (node) {
             variable.identifiers.push(node);

--- a/test/get-declared-variables.coffee
+++ b/test/get-declared-variables.coffee
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+#  Copyright (C) 2015 Toru Nagashima
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+#  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+expect = require('chai').expect
+esrecurse = require 'esrecurse'
+espree = require '../third_party/espree'
+escope = require '..'
+
+describe 'ScopeManager.prototype.getDeclaredVariables', ->
+
+    verify = (ast, type, expectedNamesList) ->
+        scopeManager = escope.analyze ast,
+            ecmaVersion: 6
+            sourceType: 'module'
+
+        visitor = {}
+        visitor[type] = (node) ->
+            expected = expectedNamesList.shift()
+            actual = scopeManager.getDeclaredVariables node
+
+            expect(actual).to.have.length expected.length
+            if actual.length > 0
+                for i in [0..actual.length-1]
+                    expect(actual[i].name).to.be.equal expected[i]
+
+            @visitChildren node
+
+        esrecurse.visit ast, visitor
+
+        expect(expectedNamesList).to.have.length 0
+
+
+    it 'should get variables that declared on `VariableDeclaration`', ->
+        ast = espree """
+        var {a, x: [b], y: {c = 0}} = foo;
+        let {d, x: [e], y: {f = 0}} = foo;
+        const {g, x: [h], y: {i = 0}} = foo, {j, k = function() { let l; }} = bar;
+        """
+
+        verify ast, 'VariableDeclaration', [
+            ['a', 'b', 'c']
+            ['d', 'e', 'f']
+            ['g', 'h', 'i', 'j', 'k']
+            ['l']
+        ]
+
+
+    it 'should get variables that declared on `VariableDeclaration` in for-in/of', ->
+        ast = espree """
+        for (var {a, x: [b], y: {c = 0}} in foo) {
+            let g;
+        }
+        for (let {d, x: [e], y: {f = 0}} of foo) {
+            let h;
+        }
+        """
+
+        verify ast, 'VariableDeclaration', [
+            ['a', 'b', 'c']
+            ['g']
+            ['d', 'e', 'f']
+            ['h']
+        ]
+
+
+    it 'should get variables that declared on `VariableDeclarator`', ->
+        ast = espree """
+        var {a, x: [b], y: {c = 0}} = foo;
+        let {d, x: [e], y: {f = 0}} = foo;
+        const {g, x: [h], y: {i = 0}} = foo, {j, k = function() { let l; }} = bar;
+        """
+
+        verify ast, 'VariableDeclarator', [
+            ['a', 'b', 'c']
+            ['d', 'e', 'f']
+            ['g', 'h', 'i']
+            ['j', 'k']
+            ['l']
+        ]
+
+
+    it 'should get variables that declared on `FunctionDeclaration`', ->
+        ast = espree """
+        function foo({a, x: [b], y: {c = 0}}, [d, e]) {
+            let z;
+        }
+        function bar({f, x: [g], y: {h = 0}}, [i, j = function(q) { let w; }]) {
+            let z;
+        }
+        """
+
+        verify ast, 'FunctionDeclaration', [
+            ['foo', 'a', 'b', 'c', 'd', 'e']
+            ['bar', 'f', 'g', 'h', 'i', 'j']
+        ]
+
+
+    it 'should get variables that declared on `FunctionExpression`', ->
+        ast = espree """
+        (function foo({a, x: [b], y: {c = 0}}, [d, e]) {
+            let z;
+        });
+        (function bar({f, x: [g], y: {h = 0}}, [i, j = function(q) { let w; }]) {
+            let z;
+        });
+        """
+
+        verify ast, 'FunctionExpression', [
+            ['foo', 'a', 'b', 'c', 'd', 'e']
+            ['bar', 'f', 'g', 'h', 'i', 'j']
+            ['q']
+        ]
+
+
+    it 'should get variables that declared on `ArrowFunctionExpression`', ->
+        ast = espree """
+        (({a, x: [b], y: {c = 0}}, [d, e]) => {
+            let z;
+        });
+        (({f, x: [g], y: {h = 0}}, [i, j]) => {
+            let z;
+        });
+        """
+
+        verify ast, 'ArrowFunctionExpression', [
+            ['a', 'b', 'c', 'd', 'e']
+            ['f', 'g', 'h', 'i', 'j']
+        ]
+
+
+    it 'should get variables that declared on `ClassDeclaration`', ->
+        ast = espree """
+        class A { foo(x) { let y; } }
+        class B { foo(x) { let y; } }
+        """
+
+        verify ast, 'ClassDeclaration', [
+            ['A', 'A'] # outer scope's and inner scope's.
+            ['B', 'B']
+        ]
+
+
+    it 'should get variables that declared on `ClassExpression`', ->
+        ast = espree """
+        (class A { foo(x) { let y; } });
+        (class B { foo(x) { let y; } });
+        """
+
+        verify ast, 'ClassExpression', [
+            ['A']
+            ['B']
+        ]
+
+
+    it 'should get variables that declared on `CatchClause`', ->
+        ast = espree """
+        try {} catch ({a, b}) {
+            let x;
+            try {} catch ({c, d}) {
+                let y;
+            }
+        }
+        """
+
+        verify ast, 'CatchClause', [
+            ['a', 'b']
+            ['c', 'd']
+        ]
+
+
+    it 'should get variables that declared on `ImportDeclaration`', ->
+        ast = espree """
+        import "aaa";
+        import * as a from "bbb";
+        import b, {c, x as d} from "ccc";
+        """, sourceType: 'module'
+
+        verify ast, 'ImportDeclaration', [
+            []
+            ['a']
+            ['b', 'c', 'd']
+        ]
+
+
+    it 'should get variables that declared on `ImportSpecifier`', ->
+        ast = espree """
+        import "aaa";
+        import * as a from "bbb";
+        import b, {c, x as d} from "ccc";
+        """, sourceType: 'module'
+
+        verify ast, 'ImportSpecifier', [
+            ['c']
+            ['d']
+        ]
+
+
+    it 'should get variables that declared on `ImportDefaultSpecifier`', ->
+        ast = espree """
+        import "aaa";
+        import * as a from "bbb";
+        import b, {c, x as d} from "ccc";
+        """, sourceType: 'module'
+
+        verify ast, 'ImportDefaultSpecifier', [
+            ['b']
+        ]
+
+
+    it 'should get variables that declared on `ImportNamespaceSpecifier`', ->
+        ast = espree """
+        import "aaa";
+        import * as a from "bbb";
+        import b, {c, x as d} from "ccc";
+        """, sourceType: 'module'
+
+        verify ast, 'ImportNamespaceSpecifier', [
+            ['a']
+        ]
+
+
+# vim: set sw=4 ts=4 et tw=80 :


### PR DESCRIPTION
Currently, we have a way to get the declaring node from each variable.  But we don't have a way to get the declared variables from each node.

```
[variable] --- defs[0].node ---> [node]
[variable] <------- ??? -------- [node]
```

For ES2015 Destructuring Assignments, the way to get the declared variables from each node is hard.

```js
let {a: [x, y, ...z], b: w = function(c, d) { let d; }} = foo;
//--------
esrecurse.visit(ast, {
    "VariableDeclaration": function(node) {
        if (node.kind === "let") {
            // How to get declared variables?
        }
    }
});
```

This proposal adds an easy way to get declared variables from each node.

----

### `getDeclaredVariables(node: Esprima.Node): Variables[]`

This is a method of `ScopeManager`.
When an AST node was given, this returns variables that its `defs[].node` or `defs[].parent` is same as the node.
The order of this method is `O(1)`.

* Why isn't this method `Scope`'s? - Because there are nodes that creates variables into several scopes.