### PR TITLE
Fix: duplicate declared variables.

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -327,7 +327,9 @@ export default class Scope {
             variables = [];
             this.__declaredVariables.set(node, variables);
         }
-        variables.push(variable);
+        if (variables.indexOf(variable) === -1) {
+            variables.push(variable);
+        }
     }
 
     __defineGeneric(name, set, variables, node, def) {

--- a/test/get-declared-variables.coffee
+++ b/test/get-declared-variables.coffee
@@ -239,4 +239,13 @@ describe 'ScopeManager.prototype.getDeclaredVariables', ->
         ]
 
 
+    it 'should not get duplicate even if it\'s declared twice', ->
+        ast = espree """
+        var a = 0, a = 1;
+        """
+
+        verify ast, 'VariableDeclaration', [
+            ['a']
+        ]
+
 # vim: set sw=4 ts=4 et tw=80 :


### PR DESCRIPTION
When a declaration declared two variables which are the same name, `scopeManager.getDeclaredVariables()` returned two of the same variable instance.

```js
var a = 0, a = 1;
```

```js
var variables = scopeManager.getDeclaredVariables(node);
console.log(variables.length === 2); // true
console.log(variables[0] === variables[1]); // true
```

This PR make `scopeManager.getDeclaredVariables` removing duplicate.