### PR TITLE
Extract PatternVisitor to easily patch it

### DIFF
--- a/src/pattern-visitor.js
+++ b/src/pattern-visitor.js
@@ -1,0 +1,134 @@
+/*
+  Copyright (C) 2015 Yusuke Suzuki <utatane.tea@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import { Syntax } from 'estraverse';
+import esrecurse from 'esrecurse';
+
+function getLast(xs) {
+    return xs[xs.length - 1] || null;
+}
+
+export default class PatternVisitor extends esrecurse.Visitor {
+    static isPattern(node) {
+        var nodeType = node.type;
+        return (
+            nodeType === Syntax.Identifier ||
+            nodeType === Syntax.ObjectPattern ||
+            nodeType === Syntax.ArrayPattern ||
+            nodeType === Syntax.SpreadElement ||
+            nodeType === Syntax.RestElement ||
+            nodeType === Syntax.AssignmentPattern
+        );
+    }
+
+    constructor(rootPattern, callback) {
+        super();
+        this.rootPattern = rootPattern;
+        this.callback = callback;
+        this.assignments = [];
+        this.rightHandNodes = [];
+        this.restElements = [];
+    }
+
+    Identifier(pattern) {
+        const lastRestElement = getLast(this.restElements);
+        this.callback(pattern, {
+            topLevel: pattern === this.rootPattern,
+            rest: lastRestElement != null && lastRestElement.argument === pattern,
+            assignments: this.assignments
+        });
+    }
+
+    Property(property) {
+        // Computed property's key is a right hand node.
+        if (property.computed) {
+            this.rightHandNodes.push(property.key);
+        }
+
+        // If it's shorthand, its key is same as its value.
+        // If it's shorthand and has its default value, its key is same as its value.left (the value is AssignmentPattern).
+        // If it's not shorthand, the name of new variable is its value's.
+        this.visit(property.value);
+    }
+
+    ArrayPattern(pattern) {
+        var i, iz, element;
+        for (i = 0, iz = pattern.elements.length; i < iz; ++i) {
+            element = pattern.elements[i];
+            this.visit(element);
+        }
+    }
+
+    AssignmentPattern(pattern) {
+        this.assignments.push(pattern);
+        this.visit(pattern.left);
+        this.rightHandNodes.push(pattern.right);
+        this.assignments.pop();
+    }
+
+    RestElement(pattern) {
+        this.restElements.push(pattern);
+        this.visit(pattern.argument);
+        this.restElements.pop();
+    }
+
+    MemberExpression(node) {
+        // Computed property's key is a right hand node.
+        if (node.computed) {
+            this.rightHandNodes.push(node.property);
+        }
+        // the object is only read, write to its property.
+        this.rightHandNodes.push(node.object);
+    }
+
+    //
+    // ForInStatement.left and AssignmentExpression.left are LeftHandSideExpression.
+    // By spec, LeftHandSideExpression is Pattern or MemberExpression.
+    //   (see also: https://github.com/estree/estree/pull/20#issuecomment-74584758)
+    // But espree 2.0 and esprima 2.0 parse to ArrayExpression, ObjectExpression, etc...
+    //
+
+    SpreadElement(node) {
+        this.visit(node.argument);
+    }
+
+    ArrayExpression(node) {
+        node.elements.forEach(this.visit, this);
+    }
+
+    AssignmentExpression(node) {
+        this.assignments.push(node);
+        this.visit(node.left);
+        this.rightHandNodes.push(node.right);
+        this.assignments.pop();
+    }
+
+    CallExpression(node) {
+        // arguments are right hand nodes.
+        node.arguments.forEach(a => { this.rightHandNodes.push(a); });
+        this.visit(node.callee);
+    }
+}
+
+/* vim: set sw=4 ts=4 et tw=80 : */

--- a/src/referencer.js
+++ b/src/referencer.js
@@ -25,102 +25,9 @@ import { Syntax } from 'estraverse';
 import esrecurse from 'esrecurse';
 import Reference from './reference';
 import Variable from './variable';
+import PatternVisitor from './pattern-visitor';
 import { ParameterDefinition, Definition } from './definition';
 import assert from 'assert';
-
-class PatternVisitor extends esrecurse.Visitor {
-    constructor(rootPattern, callback) {
-        super();
-        this.rootPattern = rootPattern;
-        this.callback = callback;
-        this.assignments = [];
-        this.rightHandNodes = [];
-        this.restElements = [];
-    }
-
-    Identifier(pattern) {
-        const lastRestElement = getLast(this.restElements);
-        this.callback(pattern, {
-            topLevel: pattern === this.rootPattern,
-            rest: lastRestElement != null && lastRestElement.argument === pattern,
-            assignments: this.assignments
-        });
-    }
-
-    Property(property) {
-        // Computed property's key is a right hand node.
-        if (property.computed) {
-            this.rightHandNodes.push(property.key);
-        }
-
-        // If it's shorthand, its key is same as its value.
-        // If it's shorthand and has its default value, its key is same as its value.left (the value is AssignmentPattern).
-        // If it's not shorthand, the name of new variable is its value's.
-        this.visit(property.value);
-    }
-
-    ArrayPattern(pattern) {
-        var i, iz, element;
-        for (i = 0, iz = pattern.elements.length; i < iz; ++i) {
-            element = pattern.elements[i];
-            this.visit(element);
-        }
-    }
-
-    AssignmentPattern(pattern) {
-        this.assignments.push(pattern);
-        this.visit(pattern.left);
-        this.rightHandNodes.push(pattern.right);
-        this.assignments.pop();
-    }
-
-    RestElement(pattern) {
-        this.restElements.push(pattern);
-        this.visit(pattern.argument);
-        this.restElements.pop();
-    }
-
-    MemberExpression(node) {
-        // Computed property's key is a right hand node.
-        if (node.computed) {
-            this.rightHandNodes.push(node.property);
-        }
-        // the object is only read, write to its property.
-        this.rightHandNodes.push(node.object);
-    }
-
-    //
-    // ForInStatement.left and AssignmentExpression.left are LeftHandSideExpression.
-    // By spec, LeftHandSideExpression is Pattern or MemberExpression.
-    //   (see also: https://github.com/estree/estree/pull/20#issuecomment-74584758)
-    // But espree 2.0 and esprima 2.0 parse to ArrayExpression, ObjectExpression, etc...
-    //
-
-    SpreadElement(node) {
-        this.visit(node.argument);
-    }
-
-    ArrayExpression(node) {
-        node.elements.forEach(this.visit, this);
-    }
-
-    AssignmentExpression(node) {
-        this.assignments.push(node);
-        this.visit(node.left);
-        this.rightHandNodes.push(node.right);
-        this.assignments.pop();
-    }
-
-    CallExpression(node) {
-        // arguments are right hand nodes.
-        node.arguments.forEach(a => { this.rightHandNodes.push(a); });
-        this.visit(node.callee);
-    }
-}
-
-function getLast(xs) {
-    return xs[xs.length - 1] || null;
-}
 
 function traverseIdentifierInPattern(rootPattern, referencer, callback) {
     // Call the callback at left hand identifier nodes, and Collect right hand nodes.
@@ -131,18 +38,6 @@ function traverseIdentifierInPattern(rootPattern, referencer, callback) {
     if (referencer != null) {
         visitor.rightHandNodes.forEach(referencer.visit, referencer);
     }
-}
-
-function isPattern(node) {
-    var nodeType = node.type;
-    return (
-        nodeType === Syntax.Identifier ||
-        nodeType === Syntax.ObjectPattern ||
-        nodeType === Syntax.ArrayPattern ||
-        nodeType === Syntax.SpreadElement ||
-        nodeType === Syntax.RestElement ||
-        nodeType === Syntax.AssignmentPattern
-    );
 }
 
 // Importing ImportDeclaration.
@@ -442,7 +337,7 @@ export default class Referencer extends esrecurse.Visitor {
     }
 
     AssignmentExpression(node) {
-        if (isPattern(node.left)) {
+        if (PatternVisitor.isPattern(node.left)) {
             if (node.operator === '=') {
                 this.visitPattern(node.left, {processRightHandNodes: true}, (pattern, info) => {
                     var maybeImplicitGlobal = null;
@@ -506,7 +401,7 @@ export default class Referencer extends esrecurse.Visitor {
     }
 
     UpdateExpression(node) {
-        if (isPattern(node.argument)) {
+        if (PatternVisitor.isPattern(node.argument)) {
             this.currentScope().__referencing(node.argument, Reference.RW, null);
         } else {
             this.visitChildren(node);


### PR DESCRIPTION
This allow external users to extend escope with SpreadProperty support.

ref #88