### PR TITLE
`childVisitorKeys` and `fallback` options

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "es6-map": "^0.1.3",
     "es6-weak-map": "^2.0.1",
-    "esrecurse": "^3.1.1",
+    "esrecurse": "^4.0.0",
     "estraverse": "^4.1.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,9 @@ function defaultOptions() {
         nodejsScope: false,
         impliedStrict: false,
         sourceType: 'script',  // one of ['script', 'module']
-        ecmaVersion: 5
+        ecmaVersion: 5,
+        childVisitorKeys: null,
+        fallback: 'iteration'
     };
 }
 
@@ -72,7 +74,7 @@ function updateDeeply(target, override) {
     var key, val;
 
     function isHashObject(target) {
-        return typeof target === 'object' && target instanceof Object && !(target instanceof RegExp);
+        return typeof target === 'object' && target instanceof Object && !(target instanceof Array) && !(target instanceof RegExp);
     }
 
     for (key in override) {
@@ -108,6 +110,8 @@ function updateDeeply(target, override) {
  * (if ecmaVersion >= 5).
  * @param {string} [providedOptions.sourceType='script']- the source type of the script. one of 'script' and 'module'
  * @param {number} [providedOptions.ecmaVersion=5]- which ECMAScript version is considered
+ * @param {Object} [providedOptions.childVisitorKeys=null] - Additional known visitor keys. See [esrecurse](https://github.com/estools/esrecurse)'s the `childVisitorKeys` option.
+ * @param {string} [providedOptions.fallback='iteration'] - A kind of the fallback in order to encounter with unknown node. See [esrecurse](https://github.com/estools/esrecurse)'s the `fallback` option.
  * @return {ScopeManager}
  */
 export function analyze(tree, providedOptions) {
@@ -117,7 +121,7 @@ export function analyze(tree, providedOptions) {
 
     scopeManager = new ScopeManager(options);
 
-    referencer = new Referencer(scopeManager);
+    referencer = new Referencer(options, scopeManager);
     referencer.visit(tree);
 
     assert(scopeManager.__currentScope === null, 'currentScope should be null.');

--- a/src/pattern-visitor.js
+++ b/src/pattern-visitor.js
@@ -42,8 +42,8 @@ export default class PatternVisitor extends esrecurse.Visitor {
         );
     }
 
-    constructor(rootPattern, callback) {
-        super();
+    constructor(options, rootPattern, callback) {
+        super(null, options);
         this.rootPattern = rootPattern;
         this.callback = callback;
         this.assignments = [];

--- a/src/referencer.js
+++ b/src/referencer.js
@@ -29,9 +29,9 @@ import PatternVisitor from './pattern-visitor';
 import { ParameterDefinition, Definition } from './definition';
 import assert from 'assert';
 
-function traverseIdentifierInPattern(rootPattern, referencer, callback) {
+function traverseIdentifierInPattern(options, rootPattern, referencer, callback) {
     // Call the callback at left hand identifier nodes, and Collect right hand nodes.
-    var visitor = new PatternVisitor(rootPattern, callback);
+    var visitor = new PatternVisitor(options, rootPattern, callback);
     visitor.visit(rootPattern);
 
     // Process the right hand nodes recursively.
@@ -48,7 +48,7 @@ function traverseIdentifierInPattern(rootPattern, referencer, callback) {
 
 class Importer extends esrecurse.Visitor {
     constructor(declaration, referencer) {
-        super();
+        super(null, referencer.options);
         this.declaration = declaration;
         this.referencer = referencer;
     }
@@ -91,8 +91,9 @@ class Importer extends esrecurse.Visitor {
 
 // Referencing variables and creating bindings.
 export default class Referencer extends esrecurse.Visitor {
-    constructor(scopeManager) {
-        super();
+    constructor(options, scopeManager) {
+        super(null, options);
+        this.options = options;
         this.scopeManager = scopeManager;
         this.parent = null;
         this.isInnerMethodDefinition = false;
@@ -155,6 +156,7 @@ export default class Referencer extends esrecurse.Visitor {
             options = {processRightHandNodes: false}
         }
         traverseIdentifierInPattern(
+            this.options,
             node,
             options.processRightHandNodes ? this : null,
             callback);

--- a/test/child-visitor-keys.js
+++ b/test/child-visitor-keys.js
@@ -1,0 +1,102 @@
+// -*- coding: utf-8 -*-
+//  Copyright (C) 2016 Yusuke Suzuki <utatane.tea@gmail.com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+//  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { expect } from 'chai';
+import esprima from 'esprima';
+import { analyze } from '..';
+
+describe('childVisitorKeys option', function() {
+    it('should handle as a known node if the childVisitorKeys option was given.', function() {
+        const ast = esprima.parse(`
+            var foo = 0;
+        `);
+
+        ast.body[0].declarations[0].init.type = 'NumericLiteral';
+
+        // should no error
+        analyze(
+            ast,
+            {
+                fallback: 'none',
+                childVisitorKeys: {
+                    NumericLiteral: []
+                }
+            }
+        );
+    });
+
+    it('should not visit to properties which are not given.', function() {
+        const ast = esprima.parse(`
+            let foo = bar;
+        `);
+
+        ast.body[0].declarations[0].init = {
+            type: 'TestNode',
+            argument: ast.body[0].declarations[0].init
+        };
+
+        var result = analyze(
+            ast,
+            {
+                childVisitorKeys: {
+                    TestNode: []
+                }
+            }
+        );
+
+        expect(result.scopes).to.have.length(1);
+        const globalScope = result.scopes[0];
+
+        // `bar` in TestNode has not been visited.
+        expect(globalScope.through).to.have.length(0);
+    });
+
+    it('should visit to given properties.', function() {
+        const ast = esprima.parse(`
+            let foo = bar;
+        `);
+
+        ast.body[0].declarations[0].init = {
+            type: 'TestNode',
+            argument: ast.body[0].declarations[0].init
+        };
+
+        var result = analyze(
+            ast,
+            {
+                childVisitorKeys: {
+                    TestNode: ['argument']
+                }
+            }
+        );
+
+        expect(result.scopes).to.have.length(1);
+        const globalScope = result.scopes[0];
+
+        // `bar` in TestNode has been visited.
+        expect(globalScope.through).to.have.length(1);
+        expect(globalScope.through[0].identifier.name).to.equal('bar');
+    });
+});
+
+// vim: set sw=4 ts=4 et tw=80 :

--- a/test/fallback.js
+++ b/test/fallback.js
@@ -1,0 +1,53 @@
+// -*- coding: utf-8 -*-
+//  Copyright (C) 2016 Yusuke Suzuki <utatane.tea@gmail.com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+//  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { expect } from 'chai';
+import esprima from 'esprima';
+import { analyze } from '..';
+
+describe('fallback option', function() {
+    it('should raise an error when it encountered an unknown node if no fallback.', function() {
+        const ast = esprima.parse(`
+            var foo = 0;
+        `);
+
+        ast.body[0].declarations[0].init.type = 'NumericLiteral';
+
+        expect(function() {
+            analyze(ast, {fallback: 'none'});
+        }).to.throw("Unknown node type NumericLiteral");
+    });
+
+    it('should not raise an error even if it encountered an unknown node.', function() {
+        const ast = esprima.parse(`
+            var foo = 0;
+        `);
+
+        ast.body[0].declarations[0].init.type = 'NumericLiteral';
+
+        analyze(ast); // default is `fallback: 'iteration'`
+        analyze(ast, {fallback: 'iteration'});
+    });
+});
+
+// vim: set sw=4 ts=4 et tw=80 :


### PR DESCRIPTION
This PR adds 2 options that configures the behavior when `escope` encountered unknown nodes.

- `fallback` (default is `"iteration"`) - The default behavior is as is. So it visits every enumerable property of the unknown node. If we set `"none"` to this `fallback` option then `escope` comes to just raise an error at unknown nodes. This is helpful to prevent the stack overflow caused by circular references.
- `childVisitorKeys` (default is `null`) - This option allows us to extend known nodes. This option is the same as the `childVisitorKeys` option of `esrecurse`.

For example, how to support JSX syntax:

```js
var jsxKeys = require("estraverse-fb/keys");
var result = escope.analyze(ast, {fallback: "none", childVisitorKeys: jsxKeys});
```

I like the behavior of `fallback: "none"`, but I didn't change the default behavior in order to avoid a breaking change.

Related: https://github.com/eslint/eslint/issues/5007

I'm happy to follow review and direction.