### PR TITLE
Fix meta property

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-register": "^6.3.13",
     "browserify": "^13.0.0",
     "chai": "^3.4.1",
-    "espree": "^2.2.5",
+    "espree": "^3.1.1",
     "esprima": "^2.7.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",

--- a/src/referencer.js
+++ b/src/referencer.js
@@ -573,6 +573,10 @@ export default class Referencer extends esrecurse.Visitor {
         let local = (node.id || node.local);
         this.visit(local);
     }
+
+    MetaProperty() {
+        // do nothing.
+    }
 }
 
 /* vim: set sw=4 ts=4 et tw=80 : */

--- a/test/es6-new-target.js
+++ b/test/es6-new-target.js
@@ -1,0 +1,52 @@
+// -*- coding: utf-8 -*-
+//  Copyright (C) 2014 Yusuke Suzuki <utatane.tea@gmail.com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+//  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { expect } from 'chai';
+import { analyze } from '..';
+
+const parse = require('../third_party/espree');
+
+describe('ES6 new.target', function() {
+    it('should not make references of new.target', function() {
+        const ast = parse(`
+            class A {
+                constructor() {
+                    new.target;
+                }
+            }
+        `);
+
+        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        expect(scopeManager.scopes).to.have.length(3);
+
+        const scope = scopeManager.scopes[2];
+        expect(scope.type).to.be.equal('function');
+        expect(scope.block.type).to.be.equal('FunctionExpression');
+        expect(scope.isStrict).to.be.true;
+        expect(scope.variables).to.have.length(1);
+        expect(scope.variables[0].name).to.be.equal('arguments');
+        expect(scope.references).to.have.length(0);
+    });
+});
+
+// vim: set sw=4 ts=4 et tw=80 :

--- a/third_party/espree.js
+++ b/third_party/espree.js
@@ -47,75 +47,9 @@ module.exports = function (code) {
         // top-level errors array
         tolerant: true,
 
-        // specify parsing features (default only has blockBindings: true)
-        ecmaFeatures: {
-
-            // enable parsing of arrow functions
-            arrowFunctions: true,
-
-            // enable parsing of let/const
-            blockBindings: true,
-
-            // enable parsing of destructured arrays and objects
-            destructuring: true,
-
-            // enable parsing of regular expression y flag
-            regexYFlag: true,
-
-            // enable parsing of regular expression u flag
-            regexUFlag: true,
-
-            // enable parsing of template strings
-            templateStrings: true,
-
-            // enable parsing of binary literals
-            binaryLiterals: true,
-
-            // enable parsing of ES6 octal literals
-            octalLiterals: true,
-
-            // enable parsing unicode code point escape sequences
-            unicodeCodePointEscapes: true,
-
-            // enable parsing of default parameters
-            defaultParams: true,
-
-            // enable parsing of rest parameters
-            restParams: true,
-
-            // enable parsing of for-of statement
-            forOf: true,
-
-            // enable parsing computed object literal properties
-            objectLiteralComputedProperties: true,
-
-            // enable parsing of shorthand object literal methods
-            objectLiteralShorthandMethods: true,
-
-            // enable parsing of shorthand object literal properties
-            objectLiteralShorthandProperties: true,
-
-            // Allow duplicate object literal properties (except '__proto__')
-            objectLiteralDuplicateProperties: true,
-
-            // enable parsing of generators/yield
-            generators: true,
-
-            // enable parsing spread operator
-            spread: true,
-
-            // enable parsing classes
-            classes: true,
-
-            // enable parsing of modules
-            modules: true,
-
-            // enable React JSX parsing
-            jsx: true,
-
-            // enable return in global scope
-            globalReturn: true
-        }
+        // enable es6 features.
+        ecmaVersion: 6,
+        sourceType: "module"
     });
 };
 


### PR DESCRIPTION
From https://github.com/eslint/eslint/issues/5420

I made `escope` not creating references of `new.target`.
Before, because `MetaProperty#meta` and `MetaProperty#property` are an `Identifier`, `escope` had been creating references of them.

Further reading: https://github.com/estree/estree/blob/master/es6.md#metaproperty