### PR TITLE
Remove support for Node.js versions < 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "version": "3.6.0",
   "engines": {
-    "node": ">=0.4.0"
+    "node": ">=4.0"
   },
   "maintainers": [
     {
@@ -22,8 +22,6 @@
     "url": "https://github.com/estools/escope.git"
   },
   "dependencies": {
-    "es6-map": "^0.1.3",
-    "es6-weak-map": "^2.0.1",
     "esrecurse": "^4.1.0",
     "estraverse": "^4.1.1"
   },

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -22,7 +22,6 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import WeakMap from 'es6-weak-map';
 import Scope from './scope';
 import assert from 'assert';
 

--- a/src/scope.js
+++ b/src/scope.js
@@ -23,7 +23,6 @@
 */
 
 import { Syntax } from 'estraverse';
-import Map from 'es6-map';
 
 import Reference from './reference';
 import Variable from './variable';


### PR DESCRIPTION
Travis test were not running for Node 0.10 and 0.12 and they've been out of active support for almost a year. It's time to drop support for them.

Dropping the two ponyfills makes the bundle 51kB smaller.

Fixes #113 
