### PR TITLE
build-with-babel7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["@babel/preset-env"]
 }


### PR DESCRIPTION
This is just the upstream forwarding of a patch included with the Debian package of node-escope. It update the .babelrc file to build the package with babel 7 by using @babel/present-env, instead of es2015.